### PR TITLE
Fix arrow style length issues

### DIFF
--- a/src/rules/arrow-return-style/rule.spec.ts
+++ b/src/rules/arrow-return-style/rule.spec.ts
@@ -744,6 +744,22 @@ const invalid: Array<InvalidTestCase> = [
 		options: [{ maxLen: 100, usePrettier: true }],
 		output: "items.sort((a, b) => a.name.localeCompare(b.name))",
 	},
+	{
+		code: unindent`
+			function getPlayerInventory(store: PlayerStore) {
+				return (playerId: number) => store.load(playerId).then((data) => data.inventory);
+			}
+		`,
+		errors: [{ messageId: explicitMessageId }],
+		options: [{ maxLen: 80, usePrettier: { printWidth: 80 } }],
+		output: unindent`
+			function getPlayerInventory(store: PlayerStore) {
+				return (playerId: number) => {
+					return store.load(playerId).then((data) => data.inventory);
+				};
+			}
+		`,
+	},
 ];
 
 /**

--- a/src/rules/arrow-return-style/rule.spec.ts
+++ b/src/rules/arrow-return-style/rule.spec.ts
@@ -228,6 +228,14 @@ const valid: Array<ValidTestCase> = [
 		code: "data.map(item => item.value).sort((a, b) => a.localeCompare(b))",
 		options: [{ maxLen: 100, usePrettier: true }],
 	},
+	{
+		code: unindent`
+			await playerStore.update(playerId, (data) => {
+				return { ...data, coins: data.coins + 100 };
+			});
+		`,
+		options: [{ maxLen: 80, usePrettier: { printWidth: 80 } }],
+	},
 ];
 
 const invalid: Array<InvalidTestCase> = [

--- a/src/rules/arrow-return-style/rule.ts
+++ b/src/rules/arrow-return-style/rule.ts
@@ -128,6 +128,14 @@ function buildConvertedArrowFunction(
 	return `${parameters} => ${implicitReturnText}`;
 }
 
+function buildConvertedForReturn(
+	node: TSESTree.ArrowFunctionExpression,
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	sourceCode: TSESLint.SourceCode,
+): null | string {
+	return buildConvertedArrowFunction(node, returnValue, sourceCode);
+}
+
 function buildIsolatedArrowFunction(
 	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
 	sourceCode: TSESLint.SourceCode,
@@ -215,35 +223,23 @@ function calcPrettierImplicitLength(
 	node: TSESTree.ArrowFunctionExpression,
 	prettierOptions: PrettierOptions,
 ): { isMultiline: boolean; length: number } {
-	const { sourceCode } = context;
-
-	// Handle method chain specific cases
 	const methodChainResult = calculateMethodChainLength({
 		context,
 		node,
 		prettierOptions,
 		returnValue,
-		sourceCode,
+		sourceCode: context.sourceCode,
 	});
 	if (methodChainResult) {
 		return methodChainResult;
 	}
 
-	// Standard prettier-based length calculation
-	const arrowFunctionCode = buildPrettierCode(returnValue, sourceCode, node);
-	if (arrowFunctionCode === null) {
-		return createPrettierFallbackResult(returnValue, sourceCode, node);
+	const returnStatementResult = returnStatementCalculation(returnValue, context, node);
+	if (returnStatementResult) {
+		return returnStatementResult;
 	}
 
-	const prettierResult = formatWithPrettier(arrowFunctionCode, context, prettierOptions);
-	if (prettierResult.error !== undefined) {
-		return createPrettierFallbackResult(returnValue, sourceCode, node);
-	}
-
-	return {
-		isMultiline: prettierResult.isMultiline,
-		length: prettierResult.lineLength,
-	};
+	return performStandardCalculation(returnValue, context, node, prettierOptions);
 }
 
 function calculateDirectImplicitLength(
@@ -273,12 +269,41 @@ function calculateDirectImplicitLength(
 	return lastLineBeforeArrow.length + 1 + estimatedSingleLineText.length;
 }
 
+function calculateFullLength(
+	lineStart: number,
+	returnToken: TSESTree.Token,
+	convertedArrowFunction: string,
+	sourceCode: TSESLint.SourceCode,
+): number {
+	const beforeReturn = sourceCode.text.substring(lineStart, returnToken.range[0]);
+	const returnKeyword = sourceCode.getText(returnToken);
+	const spaceAfterReturn = " ";
+	return (
+		beforeReturn.length +
+		returnKeyword.length +
+		spaceAfterReturn.length +
+		convertedArrowFunction.length
+	);
+}
+
 function calculateImplicitLength(
 	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
 	sourceCode: TSESLint.SourceCode,
 	node: TSESTree.ArrowFunctionExpression,
 ): number {
 	return calculateDirectImplicitLength(node, sourceCode, returnValue);
+}
+
+function calculateLineStart(
+	returnToken: TSESTree.Token,
+	sourceCode: TSESLint.SourceCode,
+): null | number {
+	const lineStart = sourceCode.getIndexFromLoc({
+		column: 0,
+		line: returnToken.loc.start.line,
+	});
+
+	return typeof lineStart === "number" ? lineStart : null;
 }
 
 function calculateMethodChainLength({
@@ -383,6 +408,39 @@ function checkMethodChainConversion(
 	}
 
 	return null;
+}
+
+function checkReturnStatementLength(
+	node: TSESTree.ArrowFunctionExpression,
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	sourceCode: TSESLint.SourceCode,
+	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>,
+): null | { isMultiline: boolean; length: number } {
+	const { maxLen } = getRuleOptions(context);
+
+	const convertedArrowFunction = buildConvertedForReturn(node, returnValue, sourceCode);
+	if (convertedArrowFunction === null) {
+		return null;
+	}
+
+	const returnToken = sourceCode.getFirstToken(node.parent);
+	if (!returnToken) {
+		return null;
+	}
+
+	const lineStart = calculateLineStart(returnToken, sourceCode);
+	if (lineStart === null) {
+		return null;
+	}
+
+	const fullLineLength = calculateFullLength(
+		lineStart,
+		returnToken,
+		convertedArrowFunction,
+		sourceCode,
+	);
+
+	return validateReturnConversion(fullLineLength, maxLen);
 }
 
 function commentsExistBetweenTokens(
@@ -986,6 +1044,29 @@ function normalizeParentheses(
 	return bodyText;
 }
 
+function performStandardCalculation(
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>,
+	node: TSESTree.ArrowFunctionExpression,
+	prettierOptions: PrettierOptions,
+): { isMultiline: boolean; length: number } {
+	const { sourceCode } = context;
+	const arrowFunctionCode = buildPrettierCode(returnValue, sourceCode, node);
+	if (arrowFunctionCode === null) {
+		return createPrettierFallbackResult(returnValue, sourceCode, node);
+	}
+
+	const prettierResult = formatWithPrettier(arrowFunctionCode, context, prettierOptions);
+	if (prettierResult.error !== undefined) {
+		return createPrettierFallbackResult(returnValue, sourceCode, node);
+	}
+
+	return {
+		isMultiline: prettierResult.isMultiline,
+		length: prettierResult.lineLength,
+	};
+}
+
 function processImplicitReturn(
 	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>,
 	node: TSESTree.ArrowFunctionExpression,
@@ -1054,6 +1135,20 @@ function reportExplicitReturn(
 		messageId: getReportMessageId(body, isObjectArrayRule),
 		node,
 	});
+}
+
+function returnStatementCalculation(
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>,
+	node: TSESTree.ArrowFunctionExpression,
+): null | { isMultiline: boolean; length: number } {
+	const { sourceCode } = context;
+
+	if (node.parent.type === AST_NODE_TYPES.ReturnStatement) {
+		return checkReturnStatementLength(node, returnValue, sourceCode, context);
+	}
+
+	return null;
 }
 
 function shouldForceArrayExplicit(
@@ -1208,6 +1303,20 @@ function validateImplicitReturnTokens(tokens: {
 } {
 	const { closingBrace, firstToken, lastToken, openingBrace } = tokens;
 	return !!(openingBrace && closingBrace && firstToken && lastToken);
+}
+
+function validateReturnConversion(
+	fullLineLength: number,
+	maxLength: number,
+): null | { isMultiline: boolean; length: number } {
+	if (fullLineLength > maxLength) {
+		return {
+			isMultiline: false,
+			length: fullLineLength,
+		};
+	}
+
+	return null;
 }
 
 const defaultOptions = [

--- a/src/rules/arrow-return-style/rule.ts
+++ b/src/rules/arrow-return-style/rule.ts
@@ -108,6 +108,26 @@ function buildCallExpressionContext({
 	return contextText.replace(arrowFunctionText, implicitArrowFunction);
 }
 
+function buildConvertedArrowFunction(
+	node: TSESTree.ArrowFunctionExpression,
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	sourceCode: TSESLint.SourceCode,
+): null | string {
+	const nodeText = sourceCode.getText(node);
+	const arrowIndex = nodeText.indexOf(" => ");
+	if (arrowIndex === -1) {
+		return null;
+	}
+
+	const parameters = nodeText.substring(0, arrowIndex);
+	const returnValueText = sourceCode.getText(returnValue);
+	const implicitReturnText = isObjectLiteral(returnValue)
+		? `(${returnValueText})`
+		: returnValueText;
+
+	return `${parameters} => ${implicitReturnText}`;
+}
+
 function buildIsolatedArrowFunction(
 	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
 	sourceCode: TSESLint.SourceCode,
@@ -197,16 +217,19 @@ function calcPrettierImplicitLength(
 ): { isMultiline: boolean; length: number } {
 	const { sourceCode } = context;
 
-	// For method chains, when evaluating existing implicit returns,
-	// we want to measure just the arrow function itself, not the entire chain context
-	const isExistingImplicit =
-		returnValue === node.body && node.body.type !== AST_NODE_TYPES.BlockStatement;
-	const isInMethodChain = isPartOfMethodChain(node);
-
-	if (isInMethodChain && isExistingImplicit) {
-		return calcMethodChainImplicitLength(returnValue, context, node, prettierOptions);
+	// Handle method chain specific cases
+	const methodChainResult = calculateMethodChainLength({
+		context,
+		node,
+		prettierOptions,
+		returnValue,
+		sourceCode,
+	});
+	if (methodChainResult) {
+		return methodChainResult;
 	}
 
+	// Standard prettier-based length calculation
 	const arrowFunctionCode = buildPrettierCode(returnValue, sourceCode, node);
 	if (arrowFunctionCode === null) {
 		return createPrettierFallbackResult(returnValue, sourceCode, node);
@@ -217,9 +240,6 @@ function calcPrettierImplicitLength(
 		return createPrettierFallbackResult(returnValue, sourceCode, node);
 	}
 
-	// For standalone declarations, we want to measure just the arrow function
-	// length since the question is "if we convert this to implicit return, how
-	// long would it be?" not "how long is the entire declaration?"
 	return {
 		isMultiline: prettierResult.isMultiline,
 		length: prettierResult.lineLength,
@@ -261,6 +281,60 @@ function calculateImplicitLength(
 	return calculateDirectImplicitLength(node, sourceCode, returnValue);
 }
 
+function calculateMethodChainLength({
+	context,
+	node,
+	prettierOptions,
+	returnValue,
+	sourceCode,
+}: {
+	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>;
+	node: TSESTree.ArrowFunctionExpression;
+	prettierOptions: PrettierOptions;
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression;
+	sourceCode: TSESLint.SourceCode;
+}): null | { isMultiline: boolean; length: number } {
+	const isExistingImplicit =
+		returnValue === node.body && node.body.type !== AST_NODE_TYPES.BlockStatement;
+	const isInMethodChain = isPartOfMethodChain(node);
+
+	if (isInMethodChain && isExistingImplicit) {
+		return calcMethodChainImplicitLength(returnValue, context, node, prettierOptions);
+	}
+
+	const isEvaluatingBlockForConversion = node.body.type === AST_NODE_TYPES.BlockStatement;
+	if (isInMethodChain && isEvaluatingBlockForConversion) {
+		const methodChainCheck = checkMethodChainConversion(node, returnValue, sourceCode, context);
+		if (methodChainCheck) {
+			return methodChainCheck;
+		}
+	}
+
+	return null;
+}
+
+function calculateMethodChainLineLength(
+	node: TSESTree.ArrowFunctionExpression,
+	convertedArrowFunction: string,
+	sourceCode: TSESLint.SourceCode,
+): null | number {
+	const arrowToken = getArrowToken(node, sourceCode);
+	if (!arrowToken) {
+		return null;
+	}
+
+	const lineStart = sourceCode.getIndexFromLoc({
+		column: 0,
+		line: arrowToken.loc.start.line,
+	});
+	if (typeof lineStart !== "number") {
+		return null;
+	}
+
+	const beforeArrow = sourceCode.text.substring(lineStart, arrowToken.range[0]);
+	return beforeArrow.length + convertedArrowFunction.length;
+}
+
 function checkForceExplicitForObject(
 	body: TSESTree.ArrowFunctionExpression["body"],
 	options: {
@@ -277,6 +351,38 @@ function checkForceExplicitForObject(
 	}
 
 	return false;
+}
+
+function checkMethodChainConversion(
+	node: TSESTree.ArrowFunctionExpression,
+	returnValue: TSESTree.BlockStatement | TSESTree.Expression,
+	sourceCode: TSESLint.SourceCode,
+	context: TSESLint.RuleContext<MessageIds, ArrowReturnStyleOptions>,
+): null | { isMultiline: boolean; length: number } {
+	const { maxLen } = getRuleOptions(context);
+
+	const convertedArrowFunction = buildConvertedArrowFunction(node, returnValue, sourceCode);
+	if (convertedArrowFunction === null) {
+		return null;
+	}
+
+	const estimatedLineLength = calculateMethodChainLineLength(
+		node,
+		convertedArrowFunction,
+		sourceCode,
+	);
+	if (estimatedLineLength === null) {
+		return null;
+	}
+
+	if (estimatedLineLength > maxLen) {
+		return {
+			isMultiline: false,
+			length: estimatedLineLength,
+		};
+	}
+
+	return null;
 }
 
 function commentsExistBetweenTokens(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - More accurate handling of arrow functions in method chains and return statements when converting between implicit and explicit returns.
  - Respects configured line-length and Prettier settings to avoid unwanted conversions and multiline spills.
  - More consistent behavior with nested arrow functions.

- Bug Fixes
  - Prevents line-length overflows after conversion.
  - Preserves necessary parentheses around object literals.
  - Ensures only the appropriate arrow function is converted in nested scenarios.

- Tests
  - Added cases covering multiline explicit returns and nested arrows under line-length constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->